### PR TITLE
✨ NLT-75 닉네임 변경

### DIFF
--- a/src/components/CircleImage/index.tsx
+++ b/src/components/CircleImage/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import styled, { css } from 'styled-components';
+
+interface ICircleImageProps {
+  url?: string;
+  size?: number;
+}
+
+const Image = styled.img<ICircleImageProps>`
+  width: ${({ size }) => size}px;
+  height: ${({ size }) => size}px;
+
+  aspect-ratio: 1;
+  object-fit: cover;
+  border-radius: 50%;
+
+  ${({ url }) => css`
+    ${url
+      ? `content: url(${url});`
+      : `background-color: #d9d9d9; border: 1px solid #727272;`}
+  `}
+`;
+
+const CircleImage = ({ url = '', size = 84 }: ICircleImageProps) => (
+  <Image url={url} size={size} />
+);
+
+export default CircleImage;

--- a/src/components/CloseButton/index.tsx
+++ b/src/components/CloseButton/index.tsx
@@ -8,6 +8,7 @@ import CloseButtonImage from '@assets/images/btn_close.png';
 
 interface ICloseButton {
   style: React.CSSProperties;
+  onClick?: () => void;
 }
 
 const CloseButtonIcon = styled.img.attrs({
@@ -20,10 +21,18 @@ const CloseButtonIcon = styled.img.attrs({
   cursor: pointer;
 `;
 
-const CloseButton = ({ style = {} }: ICloseButton) => {
+const CloseButton = ({ style = {}, onClick = () => {} }: ICloseButton) => {
   const navigate = useNavigate();
 
-  const onCloseButtonClick = () => navigate(-1);
+  const onCloseButtonClick = () => {
+    if (onClick) {
+      onClick();
+
+      return;
+    }
+
+    navigate(-1);
+  };
 
   return <CloseButtonIcon onClick={onCloseButtonClick} style={style} />;
 };

--- a/src/components/CloseButton/index.tsx
+++ b/src/components/CloseButton/index.tsx
@@ -21,7 +21,7 @@ const CloseButtonIcon = styled.img.attrs({
   cursor: pointer;
 `;
 
-const CloseButton = ({ style = {}, onClick = () => {} }: ICloseButton) => {
+const CloseButton = ({ style = {}, onClick = undefined }: ICloseButton) => {
   const navigate = useNavigate();
 
   const onCloseButtonClick = () => {

--- a/src/pages/Auth/NickName/index.tsx
+++ b/src/pages/Auth/NickName/index.tsx
@@ -1,0 +1,110 @@
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import React, { useEffect } from 'react';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+import styled from 'styled-components';
+
+import CircleImage from '@components/CircleImage';
+import CommonButton from '@components/CommonButton';
+import Header from '@components/Header';
+import Input from '@components/Input';
+import { PATH_NAMES } from '@constants/pages';
+
+interface IFormInput {
+  nickname: string;
+}
+
+const FlexColumnCenterDiv = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+`;
+
+const SignUpContainer = styled(FlexColumnCenterDiv)`
+  width: 100%;
+  height: 100vh;
+
+  padding: 24px 16px;
+  gap: 36px 0px;
+`;
+
+const NickNameForm = styled(FlexColumnCenterDiv).attrs({
+  as: 'form',
+})`
+  flex: 1;
+  width: 100%;
+  gap: 0.5rem;
+
+  justify-content: space-between;
+`;
+
+const NickName: React.FC = () => {
+  const navigate = useNavigate();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+    setValue,
+    setFocus,
+    clearErrors,
+  } = useForm<IFormInput>();
+
+  const nickNameLength = watch('nickname')?.length || 0;
+  const isConfirmButtonDisabled = !!(errors.nickname || !nickNameLength);
+
+  const onSubmit: SubmitHandler<IFormInput> = (data) => {
+    if (isConfirmButtonDisabled) {
+      return;
+    }
+
+    console.log(data);
+    handleSubmit(onSubmit);
+    navigate(PATH_NAMES.HOME);
+  };
+
+  const handleClearButtonClick = () => {
+    setValue('nickname', '');
+    clearErrors('nickname');
+    setFocus('nickname');
+  };
+
+  useEffect(() => {
+    setFocus('nickname');
+  }, [setFocus]);
+
+  return (
+    <SignUpContainer>
+      <Header title="닉네임 수정" />
+
+      <CircleImage />
+
+      <NickNameForm onSubmit={handleSubmit(onSubmit)}>
+        <Input
+          id="nickname"
+          type="text"
+          maxLength={15}
+          length={nickNameLength}
+          placeholder="닉네임을 입력하세요."
+          errors={errors}
+          register={register}
+          handleClearButtonClick={handleClearButtonClick}
+        />
+
+        <CommonButton
+          fullWidth
+          disabled={isConfirmButtonDisabled}
+          height={64}
+          target="primary"
+          label="확인"
+          onClick={handleSubmit(onSubmit)}
+        />
+      </NickNameForm>
+    </SignUpContainer>
+  );
+};
+
+export default NickName;


### PR DESCRIPTION
### 작업 내용
- 닉네임 변경 페이지를 생성하였습니다. (사진 1)
- `CircleImage` 컴포넌트화하였습니다. 
- `CloseButton` 컴포넌트에 로직을 추가하였습니다.

![localhost_3001_auth_nickname(Samsung Galaxy S8+)](https://user-images.githubusercontent.com/49024996/216778434-3eb97f4a-dc0b-45b3-b0b5-ca8a9f33bef2.png)
